### PR TITLE
Add output to syslog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcoming release
+
+- Add `gunicorn_syslog` parameter to enable sending `stdout` and `stderr`
+  output to syslog.
+
 ## 0.1.0
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An Ansible role for installing and configuring gunicorn. Provides the `Restart g
 - `gunicorn_app_name` - name of app which will be used as the name of the service (default `"gunicorn"`)
 - `gunicorn_workers` - number of workers to pre-fork (default: `8`)
 - `gunicorn_accesslog` - access log file location (default: `"-"`)
-- `gunicorn_errorlog` - error log file location (default: `"/var/lib/gunicorn/gunicorn.log"`)
+- `gunicorn_errorlog` - error log file location (default: `"-"`)
 - `gunicorn_syslog` - send `stdout` and `stderr` output to syslog (default: `true`)
 - `gunicorn_bind` - address and port to bind to (default: `"127.0.0.1:8000"`)
 - `gunicorn_reload` - reload after each request (default: `"false"`)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An Ansible role for installing and configuring gunicorn. Provides the `Restart g
 - `gunicorn_workers` - number of workers to pre-fork (default: `8`)
 - `gunicorn_accesslog` - access log file location (default: `"-"`)
 - `gunicorn_errorlog` - error log file location (default: `"/var/lib/gunicorn/gunicorn.log"`)
+- `gunicorn_syslog` - send `stdout` and `stderr` output to syslog (default: `true`)
 - `gunicorn_bind` - address and port to bind to (default: `"127.0.0.1:8000"`)
 - `gunicorn_reload` - reload after each request (default: `"false"`)
 - `gunicorn_loglevel` - log level (default: `"info"`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ gunicorn_accesslog: "-"
 gunicorn_bind: "127.0.0.1:8000"
 gunicorn_reload: false
 gunicorn_loglevel: "info"
+gunicorn_syslog: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ gunicorn_version: "19.2.1"
 gunicorn_user: "gunicorn"
 gunicorn_app_name: "gunicorn"
 gunicorn_workers: 8
-gunicorn_errorlog: "/var/lib/gunicorn/gunicorn.log"
+gunicorn_errorlog: "-"
 gunicorn_accesslog: "-"
 gunicorn_bind: "127.0.0.1:8000"
 gunicorn_reload: false

--- a/templates/upstart.conf.j2
+++ b/templates/upstart.conf.j2
@@ -7,4 +7,4 @@ respawn
 setuid {{ gunicorn_user }}
 chdir {{ gunicorn_app_dir }}
 
-exec gunicorn --config /etc/gunicorn/{{ gunicorn_app_name }}.py {{ gunicorn_wsgi }}
+exec gunicorn --config /etc/gunicorn/{{ gunicorn_app_name }}.py {{ gunicorn_wsgi }} {% if gunicorn_syslog %} 2>&1 | logger -t {{ gunicorn_app_name }} {% endif %}


### PR DESCRIPTION
## Overview

This allows applications which use this role to specify logging to syslog.
### Notes

Logging to syslog is enabled by default, so this will be a breaking change. We could make this `false` by default if we do not want to release a new major version.
### Testing
- Inside `examples`, run `vagrant up` or `vagrant provision`
- `vagrant ssh -c 'sudo tail -f /var/log/syslog'`
- Point web browser towards `http://localhost:8000/` and verify log entry is generated
