### PR TITLE
Scale workers based on number of CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ An Ansible role for installing and configuring gunicorn. Provides the `Restart g
 - `gunicorn_version` - version of gunicorn to install (default: `"19.2.1"`)
 - `gunicorn_user` - user to run gunicorn as. will create if doesn't exist. (default: `"gunicorn"`)
 - `gunicorn_app_name` - name of app which will be used as the name of the service (default `"gunicorn"`)
-- `gunicorn_workers` - number of workers to pre-fork (default: `8`)
+- `gunicorn_dynamic_workers` - dynamically generate workers based on the number of CPUs. This overrides the value of `gunicorn_workers` (default: `False`).
+- `gunicorn_cpu_coefficient` - Coefficient for scaling workers based on CPU. When this value is set along with `gunicorn_dynamic_workers`, gunicorn will fork `(gunicorn_cpu_coefficient * # of CPUs) + 1` workers (default: `2`).
+- `gunicorn_workers` - number of workers to pre-fork. This value will be overridden if `gunicorn_dynamic_workers` is True (default: `8`).
 - `gunicorn_accesslog` - access log file location (default: `"-"`)
 - `gunicorn_errorlog` - error log file location (default: `"-"`)
 - `gunicorn_syslog` - send `stdout` and `stderr` output to syslog (default: `True`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@ gunicorn_start_on: "local-filesystems and net-device-up IFACE!=lo"
 gunicorn_version: "19.2.1"
 gunicorn_user: "gunicorn"
 gunicorn_app_name: "gunicorn"
+gunicorn_dynamic_workers: False
+gunicorn_cpu_coefficient: 2
 gunicorn_workers: 8
 gunicorn_errorlog: "-"
 gunicorn_accesslog: "-"

--- a/templates/gunicorn.py.j2
+++ b/templates/gunicorn.py.j2
@@ -1,5 +1,10 @@
-bind = '{{ gunicorn_bind }}'
+{% if gunicorn_dynamic_workers %}
+import multiprocessing
+workers = ({{ gunicorn_cpu_coefficient }} * multiprocessing.cpu_count()) + 1
+{% else %}
 workers = {{ gunicorn_workers }}
+{% endif %}
+bind = '{{ gunicorn_bind }}'
 accesslog = {% if gunicorn_accesslog %}'{{ gunicorn_accesslog }}'{% else %}None{% endif %}
 
 errorlog = {% if gunicorn_errorlog %}'{{ gunicorn_errorlog }}'{% else %}None{% endif %}


### PR DESCRIPTION
Add the option to scale the amount of gunicorn workers based on the number of CPUs a machine has. Also make the factor by which they're scaled, configurable.

# Notes
I left the ability to "hardcode" the worker count intact because I think it has value when provisioning in development/when machine size is fixed.

# Testing

* Add `gunicorn_dynamic_workers` to `examples/site.yml`, then `vagrant up --provision`.
```diff
diff --git a/examples/site.yml b/examples/site.yml
index 03810dd..75b4953 100644
--- a/examples/site.yml
+++ b/examples/site.yml
@@ -13,6 +13,7 @@
     gunicorn_app_dir: /var/lib/gunicorn
     gunicorn_wsgi: hello_world
     gunicorn_loglevel: "debug"
+    gunicorn_dynamic_workers: True
     gunicorn_accesslog: False
     gunicorn_errorlog: "-"
     gunicorn_reload: True
```
* Check that the total number of gunicorn threads is 4 (1 main process + ((2 * 1 CPU) + 1))

Fixes #5 