### PR TITLE
Add systemd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .vagrant
+*.retry

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -16,6 +16,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"
-    ansible.sudo = true
+    ansible.become = true
   end
 end

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,1 @@
-azavea.pip,0.1.0
+azavea.pip,1.0.0

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -9,6 +9,7 @@
     - { role: "gunicorn.example" }
 
   vars:
+    pip_version: "9.0.*"
     gunicorn_bind: "0.0.0.0:8000"
     gunicorn_app_dir: /var/lib/gunicorn
     gunicorn_wsgi: hello_world

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,14 @@
   template: src=gunicorn.py.j2 dest=/etc/gunicorn/{{ gunicorn_app_name }}.py
   notify: Restart gunicorn
 
-- name: Install upstart script
+- name: Install Upstart service configuration
   template: src=upstart.conf.j2 dest=/etc/init/{{ gunicorn_app_name }}.conf
   notify: Restart gunicorn
+  when: ansible_service_mgr == "upstart"
+
+- name: Install systemd service configuration 
+  template: src=systemd.conf.j2
+            dest=/etc/systemd/system/{{ gunicorn_app_name }}.service
+            mode="0755"
+  notify: Restart gunicorn
+  when: ansible_service_mgr == "systemd"

--- a/templates/systemd.conf.j2
+++ b/templates/systemd.conf.j2
@@ -1,0 +1,25 @@
+[Unit]
+Description = {{ gunicorn_app_name }}
+After = network.target
+
+[Service]
+PermissionsStartOnly = true
+PIDFile = /run/{{ gunicorn_app_name }}/{{ gunicorn_app_name }}.pid
+User = {{ gunicorn_user }}
+Group = {{ gunicorn_user }}
+WorkingDirectory = {{ gunicorn_app_dir }}
+ExecStartPre = /bin/mkdir /run/{{ gunicorn_app_name }}
+ExecStartPre = /bin/chown -R {{ gunicorn_user }}:{{ gunicorn_user }} /run/{{ gunicorn_app_name }}
+ExecStart = /usr/bin/env gunicorn --pid /run/{{ gunicorn_app_name }}/{{ gunicorn_app_name }}.pid --config /etc/gunicorn/{{ gunicorn_app_name }}.py {{ gunicorn_wsgi }}
+ExecReload = /bin/kill -s HUP $MAINPID
+ExecStop = /bin/kill -s TERM $MAINPID
+ExecStopPost = /bin/rm -rf /run/{{ gunicorn_app_name }}
+PrivateTmp = true
+{% if gunicorn_syslog -%}
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier={{ gunicorn_app_name }}
+{% endif %}
+
+[Install]
+WantedBy = multi-user.target


### PR DESCRIPTION
When `ansible_service_mgr` is set to `systemd`, use the accompanying Unit file vs. the default Upstart service configuration. In addition, ensure that the Upstart service configuration is used when `ansible_service_mgr` is set to `upstart`.

A few other tweaks were needed to the example project in order to test things properly.

Fixes https://github.com/azavea/ansible-gunicorn/issues/7

---

**Testing**

First, bring up the example project using this branch and ensure that the following operations work:

- `ps aux | grep gunicorn` shows a number of Gunicorn processes
- Log output is being sent to `/var/log/syslog`
- `service gunicorn (start|stop|restart|status` work appropriately

Then, tear down the virtual machine and apply the following patch:

```diff
diff --git a/examples/Vagrantfile b/examples/Vagrantfile
index 1d9649f..241f84c 100644
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -10,7 +10,8 @@ if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  # config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.network "forwarded_port", guest: 8000, host: 8000
```

Once applied, test the same operations above to ensure that they work.