### PR TITLE
Make value of WantedBy in unit file a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Ansible role for installing and configuring gunicorn. Provides the `Restart g
 
 ## Role Variables
 
-- `gunicorn_start_on` - start on string for upstart (default: `"local-filesystems and net-device-up IFACE!=lo"`)
+- `gunicorn_start_on` - start on string for Upstart, or `systemd` `WantedBy` (default: `"local-filesystems and net-device-up IFACE!=lo"`)
 - `gunicorn_version` - version of gunicorn to install (default: `"19.2.1"`)
 - `gunicorn_user` - user to run gunicorn as. will create if doesn't exist. (default: `"gunicorn"`)
 - `gunicorn_app_name` - name of app which will be used as the name of the service (default `"gunicorn"`)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,3 +27,6 @@
             mode="0755"
   notify: Restart gunicorn
   when: ansible_service_mgr == "systemd"
+
+- name: Enable gunicorn service
+  service: name={{ gunicorn_app_name }} enabled=yes

--- a/templates/systemd.conf.j2
+++ b/templates/systemd.conf.j2
@@ -22,4 +22,4 @@ SyslogIdentifier={{ gunicorn_app_name }}
 {% endif %}
 
 [Install]
-WantedBy = multi-user.target
+WantedBy = {{ gunicorn_start_on }}


### PR DESCRIPTION
Use the existing `gunicorn_start_on` variable to set the value of `WantedBy` in the `systemd` unit file. Also, ensure that the service is enabled, regardless of service manager.

---

**Testing**

Apply the following patch against this branch:

```diff
diff --git a/examples/Vagrantfile b/examples/Vagrantfile
index 1d9649f..7141c3e 100644
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -10,7 +10,7 @@ if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.network "forwarded_port", guest: 8000, host: 8000
 
diff --git a/examples/site.yml b/examples/site.yml
index 0c022c2..78fd6ec 100644
--- a/examples/site.yml
+++ b/examples/site.yml
@@ -17,4 +17,4 @@
     gunicorn_accesslog: False
     gunicorn_errorlog: "-"
     gunicorn_reload: True
-    gunicorn_start_on: "vagrant-mounted"
+    gunicorn_start_on: "vagrant.mount"
```

Then, navigate to the `examples` directory and bring up the project. After it comes up, use `vagrant reload` to restart the virtual machine. Finally, ensure that the service is still running after the restart:

```bash
$ http localhost:8000                                                                                       
HTTP/1.1 200 OK
Connection: close
Content-Type: text/plain
Date: Fri, 20 Jul 2018 22:13:57 GMT
Server: gunicorn/19.2.1
Transfer-Encoding: chunked

Hello World
```