### PR TITLE
Use .service suffix when enabling a systemd unit

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,4 +29,5 @@
   when: ansible_service_mgr == "systemd"
 
 - name: Enable gunicorn service
-  service: name={{ gunicorn_app_name }} enabled=yes
+  service: name="{{ gunicorn_app_name }}{{ (ansible_service_mgr == 'systemd') | ternary('.service', '') }}"
+           enabled=yes


### PR DESCRIPTION
This is a necessary workaround for https://github.com/ansible/ansible/issues/39116.

---

**Testing**

Apply the following patch against this branch:

```diff
diff --git a/examples/Vagrantfile b/examples/Vagrantfile
index 1d9649f..7141c3e 100644
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -10,7 +10,7 @@ if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.network "forwarded_port", guest: 8000, host: 8000
 
diff --git a/examples/site.yml b/examples/site.yml
index 0c022c2..78fd6ec 100644
--- a/examples/site.yml
+++ b/examples/site.yml
@@ -17,4 +17,4 @@
     gunicorn_accesslog: False
     gunicorn_errorlog: "-"
     gunicorn_reload: True
-    gunicorn_start_on: "vagrant-mounted"
+    gunicorn_start_on: "vagrant.mount"
```

From there, SSH into the virtual machine and ensure that the dummy service is enabled:

```bash
vagrant@vagrant:~$ sudo systemctl list-unit-files | grep guni
gunicorn.service                           enabled 
```

Lastly, reload the virtual machine and check that the service is enabled again:

```bash
$ vagrant reload
$ vagrant ssh
vagrant@vagrant:~$ sudo systemctl list-unit-files | grep guni
gunicorn.service                           enabled 
```