### PR TITLE
Make PrivateTmp configurable for systemd unit

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,4 +11,5 @@ gunicorn_accesslog: "-"
 gunicorn_bind: "127.0.0.1:8000"
 gunicorn_reload: False
 gunicorn_loglevel: "info"
+gunicorn_private_tmp: True
 gunicorn_syslog: True

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -10,7 +10,7 @@ if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.network "forwarded_port", guest: 8000, host: 8000
 

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -17,4 +17,4 @@
     gunicorn_accesslog: False
     gunicorn_errorlog: "-"
     gunicorn_reload: True
-    gunicorn_start_on: "vagrant-mounted"
+    gunicorn_start_on: "{{ 'vagrant.mount' if ansible_service_mgr == 'systemd' else 'vagrant-mounted' }}"

--- a/templates/systemd.conf.j2
+++ b/templates/systemd.conf.j2
@@ -14,7 +14,9 @@ ExecStart = /usr/bin/env gunicorn --pid /run/{{ gunicorn_app_name }}/{{ gunicorn
 ExecReload = /bin/kill -s HUP $MAINPID
 ExecStop = /bin/kill -s TERM $MAINPID
 ExecStopPost = /bin/rm -rf /run/{{ gunicorn_app_name }}
+{% if gunicorn_private_tmp -%}
 PrivateTmp = true
+{% endif %}
 {% if gunicorn_syslog -%}
 StandardOutput=syslog
 StandardError=syslog


### PR DESCRIPTION
## Overview

* Add gunicorn_private_tmp parameter and conditional
* Update example to support systemd

Fixes #11 

## Testing

By default, the `gunicorn_private_tmp` variable is set to `True`. You can change the default by applying this patch:

```diff
diff --git a/examples/site.yml b/examples/site.yml
index 78fd6ec..86c6a97 100644
--- a/examples/site.yml
+++ b/examples/site.yml
@@ -18,3 +18,4 @@
     gunicorn_errorlog: "-"
     gunicorn_reload: True
     gunicorn_start_on: "vagrant.mount"
+    gunicorn_private_tmp: False
```

Ensure the example VM comes online and check the `gunicorn.service` file:

```bash
$ vagrant up --provision
...
$ vagrant ssh -c "cat /etc/systemd/system/gunicorn.service"
```